### PR TITLE
improve person details pop-up

### DIFF
--- a/app/components/AddVisit/index.js
+++ b/app/components/AddVisit/index.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import PropTypes from 'prop-types';
-import NotFound from '@material-ui/icons/VoiceOverOff';
+import VoiceOverOff from '@material-ui/icons/VoiceOverOff';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import Save from '@material-ui/icons/Save';
 import Cancel from '@material-ui/icons/Cancel';
 import Badge from '@material-ui/core/Badge';
 import TextField from '@material-ui/core/TextField';
+import Tooltip from '@material-ui/core/Tooltip';
 
 import styles from './styles';
 
@@ -15,19 +16,23 @@ class AddVisit extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      addingVisit: false,
       note: '',
       visitState: '',
     };
     this.saveVisit = this.saveVisit.bind(this);
+    this.startVisitAdd = this.startVisitAdd.bind(this);
+  }
+  startVisitAdd(name) {
+    this.setState({ visitState: name });
+    if (!this.props.addingVisit) {
+      this.props.toggleAddingVisit();
+    }
   }
   saveVisit() {
     const { visitState, note } = this.state;
-    this.props.saveVisit({
-      note,
-      found: visitState === 'found',
-    });
-    this.setState({ addingVisit: false });
+    const found = visitState === 'Found';
+    this.props.saveVisit({ note, found });
+    this.setState({ note: '', visitState: '' });
   }
   renderBadge(content, name, icon) {
     const { classes } = this.props;
@@ -39,56 +44,74 @@ class AddVisit extends React.Component {
       </Badge>
     );
   }
+  renderHeaderButtons(visitTypes, classes, count) {
+    return visitTypes.map(({ name, icon }, key) => (
+      <div className={classes.column} key={`visit-icon-${key + 1}`}>
+        <Tooltip title={`Add visit - ${name}`} placement="top">
+          <IconButton
+            aria-label={name}
+            onClick={() => this.startVisitAdd(name)}
+          >
+            {this.renderBadge(count[name], name, icon)}
+          </IconButton>
+        </Tooltip>
+      </div>
+    ));
+  }
   renderHeader(classes, person) {
     const visitTypes = [
-      { name: 'found', icon: <CheckCircle color="secondary" /> },
-      { name: 'notFound', icon: <NotFound color="error" /> },
+      { name: 'Found', icon: <CheckCircle color="secondary" /> },
+      { name: 'NotFound', icon: <VoiceOverOff color="error" /> },
     ];
     const count = {
-      found: person.visits.filter(prsn => prsn.found).length,
-      notFound: person.visits.filter(prsn => !prsn.found).length,
+      Found: person.visits.filter(prsn => prsn.found).length,
+      NotFound: person.visits.filter(prsn => !prsn.found).length,
     };
     return (
       <div>
-        <h4 className={classes.visitLabel}>Visits: ({person.visits.length})</h4>
-        {visitTypes.map(({ name, icon }, key) => (
-          <div className={classes.column} key={`visit-icon-${key + 1}`}>
-            <IconButton
-              aria-label={name}
-              onClick={() =>
-                this.setState({ visitState: name, addingVisit: true })
-              }
-            >
-              {this.renderBadge(count[name], name, icon)}
-            </IconButton>
-          </div>
-        ))}
+        <h3 className={classes.visitLabel}>
+          Total visits: ({person.visits.length})
+        </h3>
+        {this.props.addingVisit && (
+          <h4>Add new visit ({this.state.visitState})</h4>
+        )}
+        {this.renderHeaderButtons(visitTypes, classes, count)}
       </div>
     );
   }
   renderActionButtons() {
+    const saveDisabled = !this.state.note;
+    const saveColor = saveDisabled ? 'disabled' : 'secondary';
     return (
       <div>
-        <IconButton aria-label="Save" onClick={this.saveVisit}>
-          <Save color="secondary" />
-        </IconButton>
         <IconButton
-          aria-label="Cancel"
-          onClick={() => this.setState({ addingVisit: false })}
+          aria-label="Save"
+          disabled={saveDisabled}
+          onClick={this.saveVisit}
         >
-          <Cancel color="error" />
+          <Save color={saveColor} />
         </IconButton>
+        <Tooltip title="Cancel" placement="top">
+          <IconButton
+            aria-label="Cancel"
+            onClick={this.props.toggleAddingVisit}
+          >
+            <Cancel color="error" />
+          </IconButton>
+        </Tooltip>
       </div>
     );
   }
   render() {
-    const { classes, person } = this.props;
-    const { addingVisit, note } = this.state;
+    const { classes, person, addingVisit } = this.props;
+    const { note } = this.state;
     return (
       <div className={classes.container}>
         {this.renderHeader(classes, person)}
         <div style={{ display: addingVisit ? 'inline-block' : 'none' }}>
           <TextField
+            className={classes.noteField}
+            placeholder="Add some notes.."
             value={note}
             onChange={({ target: { value } }) => this.setState({ note: value })}
             InputLabelProps={{ shrink: true }}
@@ -108,6 +131,8 @@ AddVisit.propTypes = {
   classes: PropTypes.object.isRequired,
   person: PropTypes.object.isRequired,
   saveVisit: PropTypes.func.isRequired,
+  addingVisit: PropTypes.bool.isRequired,
+  toggleAddingVisit: PropTypes.func.isRequired,
 };
 
 export default withStyles(styles)(AddVisit);

--- a/app/components/AddVisit/styles.js
+++ b/app/components/AddVisit/styles.js
@@ -16,6 +16,9 @@ const styles = theme => ({
     marginLeft: 10,
     border: `2px solid ${theme.palette.grey[200]}`,
   },
+  noteField: {
+    minWidth: 167,
+  },
 });
 
 export default styles;

--- a/app/components/AddVisit/tests/index.test.js
+++ b/app/components/AddVisit/tests/index.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import { mount } from 'enzyme';
 import { createMount } from '@material-ui/core/test-utils';
 import AddVisit from '../index';
 
@@ -9,6 +8,8 @@ describe('<AddVisit />', () => {
     person: { visits: [{ found: true, note: 'test' }] },
     classes: {},
     saveVisit: () => true,
+    addingVisit: false,
+    toggleAddingVisit: () => true,
   };
 
   it('should render with 4 IconButtons successfully', () => {
@@ -18,23 +19,30 @@ describe('<AddVisit />', () => {
     expect(rendered.find('IconButton').length).toEqual(4);
   });
 
-  it.skip('should edit note successfully', () => {
+  it('should edit and save visit successfully', done => {
     const event = { target: { value: 'newNote' } };
-    const rendered = mount(<AddVisit {...props} />);
-    expect(rendered.length).toEqual(1);
-    rendered.find('CheckCircle').simulate('click');
-    rendered.find('TextField').simulate('change', event);
-    expect(rendered.state('note')).toEqual(event.target.value);
-  });
-
-  it('should save visit successfully', done => {
     props.saveVisit = visitData => {
-      expect(visitData).toEqual({ found: true, note: '' });
+      expect(visitData).toEqual({ found: true, note: 'newNote' });
       done();
     };
     const rendered = mount(<AddVisit {...props} />);
     expect(rendered.length).toEqual(1);
     rendered.find('CheckCircle').simulate('click');
+    rendered
+      .find('textarea')
+      .at(2)
+      .simulate('change', event);
     rendered.find('Save').simulate('click');
+  });
+
+  it('should not toggle addingVisit when its already open', done => {
+    props.toggleAddingVisit = () => done('test should not trigger this..');
+    props.addingVisit = true;
+    const rendered = mount(<AddVisit {...props} />);
+    expect(rendered.length).toEqual(1);
+    rendered.find('CheckCircle').simulate('click');
+    rendered.find('VoiceOverOff').simulate('click');
+    expect(rendered.prop('addingVisit')).toEqual(props.addingVisit);
+    setTimeout(done, 100);
   });
 });

--- a/app/components/LeftDrawer/index.js
+++ b/app/components/LeftDrawer/index.js
@@ -1,9 +1,3 @@
-/**
- *
- * LeftDrawer
- *
- */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '@material-ui/core/styles/withStyles';
@@ -18,38 +12,7 @@ import {
   otherMailFolderListItems,
   actionListItems,
 } from './tileData';
-
-const drawerWidth = 240;
-
-const styles = theme => ({
-  drawerPaper: {
-    position: 'relative',
-    whiteSpace: 'nowrap',
-    width: drawerWidth,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  drawerPaperClose: {
-    overflowX: 'hidden',
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    width: theme.spacing.unit * 7,
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing.unit * 9,
-    },
-  },
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-  },
-});
+import styles from './styles';
 
 class LeftDrawer extends React.PureComponent {
   renderToggleButton(classes, toggleDrawer) {
@@ -63,17 +26,14 @@ class LeftDrawer extends React.PureComponent {
   }
   render() {
     const { classes, open, toggleDrawer, hidden } = this.props;
+    const { drawerPaper, drawerPaperClose } = classes;
+    const paper = classNames(drawerPaper, !open && drawerPaperClose);
     return (
       <Drawer
+        classes={{ paper }}
+        open={open}
         style={{ display: hidden && 'none' }}
         variant="permanent"
-        classes={{
-          paper: classNames(
-            classes.drawerPaper,
-            !open && classes.drawerPaperClose,
-          ),
-        }}
-        open={open}
       >
         {this.renderToggleButton(classes, toggleDrawer)}
         <Divider />

--- a/app/components/LeftDrawer/styles.js
+++ b/app/components/LeftDrawer/styles.js
@@ -1,0 +1,31 @@
+const styles = theme => ({
+  drawerPaper: {
+    position: 'relative',
+    whiteSpace: 'nowrap',
+    width: 240,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  drawerPaperClose: {
+    overflowX: 'hidden',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    width: theme.spacing.unit * 7,
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing.unit * 9,
+    },
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: '0 8px',
+    ...theme.mixins.toolbar,
+  },
+});
+
+export default styles;

--- a/app/components/PersonDetails/index.js
+++ b/app/components/PersonDetails/index.js
@@ -44,9 +44,10 @@ class PersonDetails extends React.PureComponent {
           this.props.handlePersonUpdate(prop, target.value)
         }
         disabled={!editMode}
-        fullWidth
         InputLabelProps={{ shrink: true }}
         label={personLabels[prop]}
+        placeholder={`Add ${personLabels[prop]}...`}
+        fullWidth
       />
     ));
     return this.addAgeRangeSlider(inputs, classes, person);

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -54,6 +54,16 @@ const styles = theme => ({
 const base = process.env.PUBLIC_PATH || '';
 
 class App extends React.Component {
+  getPrivateRoutes(token) {
+    return [
+      {
+        key: 'map-route',
+        path: `${base}/map`,
+        component: MapPage,
+        token,
+      },
+    ];
+  }
   renderHeader(drawerOpen, token) {
     return (
       <Header
@@ -81,12 +91,9 @@ class App extends React.Component {
         <Switch>
           <Route exact path={`${base}/login`} component={LoginPage} />
           <Route exact path={`${base}/`} component={LoginPage} />
-          <PrivateRoute
-            exact
-            path={`${base}/map`}
-            component={MapPage}
-            token={token}
-          />
+          {this.getPrivateRoutes(token).map(props => (
+            <PrivateRoute {...props} />
+          ))}
           <Route component={NotFoundPage} />
         </Switch>
       </main>

--- a/app/containers/MapPage/actions.js
+++ b/app/containers/MapPage/actions.js
@@ -9,6 +9,8 @@ import {
   CANCEL_ADD,
   PERSON_CLICK,
   SAVE_VISIT,
+  TOGGLE_ADDING_VISIT,
+  POPUP_CLOSE,
 } from './constants';
 
 export function setInitialLocation() {
@@ -51,19 +53,26 @@ export function saveVisit(visitData) {
   return { type: SAVE_VISIT, visitData };
 }
 
-export function mapPageActions(dispatch) {
-  return {
-    setInitialLocation: () => dispatch(setInitialLocation()),
-    addPersonStart: () => dispatch(addPersonStart()),
-    handleFormChange: (key, value) => dispatch(handleFormChange(key, value)),
-    savePersonData: () => dispatch(savePersonData()),
-    moveToStep: step => dispatch(moveToStep(step)),
-    cancelAdd: () => dispatch(cancelAdd()),
-    handleNewPersonPositionChange: data =>
-      dispatch(handleNewPersonPositionChange(data)),
-    handlePersonUpdate: (key, value) =>
-      dispatch(handlePersonUpdate(key, value)),
-    handlePersonClick: index => dispatch(handlePersonClick(index)),
-    saveVisit: visitData => dispatch(saveVisit(visitData)),
-  };
+export function toggleAddingVisit() {
+  return { type: TOGGLE_ADDING_VISIT };
 }
+
+export function onPopupClose() {
+  return { type: POPUP_CLOSE };
+}
+
+export const mapPageActions = dispatch => ({
+  setInitialLocation: () => dispatch(setInitialLocation()),
+  addPersonStart: () => dispatch(addPersonStart()),
+  handleFormChange: (key, value) => dispatch(handleFormChange(key, value)),
+  savePersonData: () => dispatch(savePersonData()),
+  moveToStep: step => dispatch(moveToStep(step)),
+  cancelAdd: () => dispatch(cancelAdd()),
+  handleNewPersonPositionChange: data =>
+    dispatch(handleNewPersonPositionChange(data)),
+  handlePersonUpdate: (key, value) => dispatch(handlePersonUpdate(key, value)),
+  handlePersonClick: index => dispatch(handlePersonClick(index)),
+  saveVisit: visitData => dispatch(saveVisit(visitData)),
+  toggleAddingVisit: () => dispatch(toggleAddingVisit()),
+  onPopupClose: () => dispatch(onPopupClose()),
+});

--- a/app/containers/MapPage/constants.js
+++ b/app/containers/MapPage/constants.js
@@ -15,3 +15,5 @@ export const UPDATE_NEW_MARKER_LOCATION =
 export const PERSON_UPDATE = 'app/MapPage/PERSON_UPDATE';
 export const PERSON_CLICK = 'app/MapPage/PERSON_CLICK';
 export const SAVE_VISIT = 'app/MapPage/SAVE_VISIT';
+export const TOGGLE_ADDING_VISIT = 'app/MapPage/TOGGLE_ADDING_VISIT';
+export const POPUP_CLOSE = 'app/MapPage/POPUP_CLOSE';

--- a/app/containers/MapPage/index.js
+++ b/app/containers/MapPage/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/prefer-stateless-function */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
@@ -81,16 +79,23 @@ export class MapPage extends React.Component {
         position={people[key].location}
         onClick={() => this.props.handlePersonClick(key)}
       >
-        <Popup>
-          <PersonDetails
+        <Popup onClose={this.props.onPopupClose}>
+          {!this.props.addingVisit && (
+            <PersonDetails
+              person={people[key]}
+              defaultAgeRange={this.props.ageRange}
+              personLabels={this.props.personLabels}
+              handlePersonUpdate={(prop, value) =>
+                this.props.handlePersonUpdate(prop, value)
+              }
+            />
+          )}
+          <AddVisit
             person={people[key]}
-            defaultAgeRange={this.props.ageRange}
-            personLabels={this.props.personLabels}
-            handlePersonUpdate={(prop, value) =>
-              this.props.handlePersonUpdate(prop, value)
-            }
+            saveVisit={this.props.saveVisit}
+            addingVisit={this.props.addingVisit}
+            toggleAddingVisit={this.props.toggleAddingVisit}
           />
-          <AddVisit person={people[key]} saveVisit={this.props.saveVisit} />
         </Popup>
       </Marker>
     ));

--- a/app/containers/MapPage/reducer.js
+++ b/app/containers/MapPage/reducer.js
@@ -13,6 +13,8 @@ import {
   PERSON_UPDATE,
   PERSON_CLICK,
   SAVE_VISIT,
+  TOGGLE_ADDING_VISIT,
+  POPUP_CLOSE,
 } from './constants';
 
 const personSchema = {
@@ -49,6 +51,7 @@ export const initialState = fromJS({
     ageRange: 'Age Range',
     visits: 'Visits',
   },
+  addingVisit: false,
 });
 
 function setInitialLocation(state, action) {
@@ -121,9 +124,13 @@ function personUpdate(state, action) {
   );
 }
 
+function toggleAddingVisit(state) {
+  return state.set('addingVisit', !state.get('addingVisit'));
+}
+
 function addPersonVisit(state, action) {
   const date = new Date();
-  return state.updateIn(
+  return toggleAddingVisit(state).updateIn(
     ['people', state.get('personCurrentlyEditing'), 'visits'],
     visits => visits.push({ ...action.visitData, date }),
   );
@@ -157,6 +164,10 @@ function mapPageReducer(state = initialState, action) {
       return state.set('personCurrentlyEditing', parseInt(action.index, 10));
     case SAVE_VISIT:
       return addPersonVisit(state, action);
+    case TOGGLE_ADDING_VISIT:
+      return toggleAddingVisit(state);
+    case POPUP_CLOSE:
+      return state.set('addingVisit', false);
     default:
       return state;
   }

--- a/app/containers/MapPage/selectors.js
+++ b/app/containers/MapPage/selectors.js
@@ -38,6 +38,9 @@ export const makeSelectDefaultAgeRange = () =>
 export const makeSelectPersonLabels = () =>
   createSelector(selectMapPage, state => state.get('personLabels').toJS());
 
+export const makeSelectAddingVisit = () =>
+  createSelector(selectMapPage, state => state.get('addingVisit'));
+
 export const allSelectors = {
   initialLocation: makeSelectInitialLocation(),
   initialLocationLoaded: makeSelectInitialLocationLoaded(),
@@ -51,4 +54,5 @@ export const allSelectors = {
   people: makeSelectPeople(),
   ageRange: makeSelectDefaultAgeRange(),
   personLabels: makeSelectPersonLabels(),
+  addingVisit: makeSelectAddingVisit(),
 };

--- a/app/containers/MapPage/tests/reducer.test.js
+++ b/app/containers/MapPage/tests/reducer.test.js
@@ -126,4 +126,14 @@ describe('mapPageReducer', () => {
     const newState = mapPageReducer(state, acts.handlePersonClick(index));
     expect(newState.get('personCurrentlyEditing')).toEqual(index);
   });
+
+  it('should toggle addingVisit correctly', () => {
+    const newState = mapPageReducer(state, acts.toggleAddingVisit());
+    expect(newState.get('addingVisit')).toEqual(true);
+  });
+
+  it('should set addingVisit=false when popup closes', () => {
+    const newState = mapPageReducer(state, acts.onPopupClose());
+    expect(newState.get('addingVisit')).toEqual(false);
+  });
 });

--- a/app/containers/MapPage/tests/selectors.test.js
+++ b/app/containers/MapPage/tests/selectors.test.js
@@ -14,6 +14,7 @@ import {
   makeSelectPeople,
   makeSelectDefaultAgeRange,
   makeSelectPersonLabels,
+  makeSelectAddingVisit,
 } from '../selectors';
 
 describe('selectMapPage', () => {
@@ -104,5 +105,11 @@ describe('selectMapPage', () => {
     const personLabels = { test: 'test' };
     const mapState12 = fromJS({ mapPage: { personLabels } });
     expect(personLabelsSelector(mapState12)).toEqual(personLabels);
+  });
+  it('should select addingVisit state correctly', () => {
+    const addingVisitSelector = makeSelectAddingVisit();
+    const addingVisit = true;
+    const mapState13 = fromJS({ mapPage: { addingVisit } });
+    expect(addingVisitSelector(mapState13)).toEqual(addingVisit);
   });
 });


### PR DESCRIPTION
:sparkles: when adding a visit on popup, person details are hidden to give space for mobile view
:hammer: LeftDrawer styles to a separate file

when pop-up is closed, `addingVisit` state is re-set to `false`
when adding visit, you can switch type of visit to `Found` or `NotFound` without needing to open-close